### PR TITLE
Track request / response removal

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,8 +31,9 @@ When instantiated, it should be passed a charm instance and a relation name.
 
   * `is_available` Whether the provider is available to take requests
   * `is_changed` Whether there are any new or changed responses which have not been acknowledged
-  * `all_responses` A list of all received responses, even if they have not changed
-  * `new_responses` A list of all responses which are new or have changed and not been acknowledged
+  * `all_responses` A list of all received responses
+  * `complete_responses` A list of all up to date received responses, even if they have not changed
+  * `new_responses` A list of all complete responses which are new or have changed and not been acknowledged
 
 ### Flags
 

--- a/loadbalancer_interface/base.py
+++ b/loadbalancer_interface/base.py
@@ -40,7 +40,9 @@ class VersionedInterface(Object):
                 for relation in sorted(relations, key=attrgetter('id'))
                 if self._schema(relation)]
 
-    def _schema(self, relation):
+    def _schema(self, relation=None):
+        if relation is None:
+            return schemas.versions[schemas.max_version]
         if relation.app not in relation.data:
             return None
         data = relation.data[relation.app]

--- a/loadbalancer_interface/base.py
+++ b/loadbalancer_interface/base.py
@@ -10,7 +10,7 @@ from ops.framework import (
 from . import schemas
 
 
-class LBBase(Object):
+class VersionedInterface(Object):
     def __init__(self, charm, relation_name):
         super().__init__(charm, relation_name)
         self.charm = weakref.proxy(charm)

--- a/loadbalancer_interface/consumer.py
+++ b/loadbalancer_interface/consumer.py
@@ -3,6 +3,7 @@ from operator import attrgetter
 from cached_property import cached_property
 
 from ops.framework import (
+    StoredState,
     EventBase,
     EventSource,
     ObjectEvents,
@@ -22,11 +23,13 @@ class LBConsumersEvents(ObjectEvents):
 class LBConsumers(VersionedInterface):
     """ API used to interact with consumers of a loadbalancer provider.
     """
+    state = StoredState()
     on = LBConsumersEvents()
 
     def __init__(self, charm, relation_name):
         super().__init__(charm, relation_name)
         self.relation_name = relation_name
+        self.state.set_default(known_ids=set())
 
         for event in (charm.on[relation_name].relation_created,
                       charm.on[relation_name].relation_joined,
@@ -65,6 +68,8 @@ class LBConsumers(VersionedInterface):
                         if addr:
                             request.backends.append(addr)
                 requests.append(request)
+        # Add any new requests to the known requests.
+        self.state.known_ids |= {req.id for req in requests}
         return requests
 
     @property
@@ -72,12 +77,19 @@ class LBConsumers(VersionedInterface):
         """A list of requests with changes or no response.
         """
         return [req for req in self.all_requests
-                if not req.response or req.response.request_hash != req.hash]
+                if not req.response or req.response.nonce != req.nonce]
+
+    @property
+    def removed_requests(self):
+        current_ids = {request.id for request in self.all_requests}
+        schema = self._schema()
+        return [schema.Request._from_id(req_id, self.relations)
+                for req_id in self.state.known_ids - current_ids]
 
     def send_response(self, request):
         """ Send a specific request's response.
         """
-        request.response.request_hash = request.hash
+        request.response.nonce = request.nonce
         key = 'response_' + request.name
         request.relation.data[self.app][key] = request.response.dumps()
         if not self.new_requests:
@@ -88,9 +100,21 @@ class LBConsumers(VersionedInterface):
             except ImportError:
                 pass  # not being used in a reactive charm
 
+    def revoke_response(self, request):
+        """ Revoke / remove the response for a given request.
+        """
+        if not request.relation:
+            # If relation is no longer available, the repsonse is gone anyway.
+            return
+        key = 'response_' + request.name
+        request.relation.data[self.app].pop(key, None)
+
+    def ack_removal(self, request):
+        self.state.known_requests.discard(request.id)
+
     @property
     def is_changed(self):
-        return bool(self.new_requests)
+        return bool(self.new_requests or self.removed_requests)
 
     def manage_flags(self):
         """ Used to interact with charms.reactive-base charms.

--- a/loadbalancer_interface/consumer.py
+++ b/loadbalancer_interface/consumer.py
@@ -92,7 +92,7 @@ class LBConsumers(VersionedInterface):
     def send_response(self, request):
         """ Send a specific request's response.
         """
-        request.response.nonce = request.nonce
+        request.response.received_hash = request.sent_hash
         key = 'response_' + request.name
         request.relation.data[self.app][key] = request.response.dumps()
         self.state.known_requests[request.id] = request.hash

--- a/loadbalancer_interface/consumer.py
+++ b/loadbalancer_interface/consumer.py
@@ -8,7 +8,7 @@ from ops.framework import (
     ObjectEvents,
 )
 
-from .base import LBBase
+from .base import VersionedInterface
 
 
 class LBRequestsChanged(EventBase):
@@ -19,7 +19,7 @@ class LBConsumersEvents(ObjectEvents):
     requests_changed = EventSource(LBRequestsChanged)
 
 
-class LBConsumers(LBBase):
+class LBConsumers(VersionedInterface):
     """ API used to interact with consumers of a loadbalancer provider.
     """
     on = LBConsumersEvents()

--- a/loadbalancer_interface/provider.py
+++ b/loadbalancer_interface/provider.py
@@ -106,13 +106,11 @@ class LBProvider(VersionedInterface):
             raise ModelError('Unit is not leader')
         if not self.relation:
             raise ModelError('Relation not available')
-        # The nonce is used to indicate to the provider that the request has
-        # changed, and for us to be able to tell when an updated request has a
-        # corresponding updated response. We can't used the request hash
-        # computed on the providing side because it may not match due to
-        # default values being filled in on that side (e.g., the backend
-        # addresses).
-        request.nonce = request.hash
+        # The sent_hash is used to tell when the provider's response has been
+        # updated to match our request. We can't used the request hash computed
+        # on the providing side because it may not match due to default values
+        # being filled in on that side (e.g., the backend addresses).
+        request.sent_hash = request.hash
         key = 'request_' + request.name
         self.relation.data[self.app][key] = request.dumps()
 
@@ -165,7 +163,7 @@ class LBProvider(VersionedInterface):
         """
         return [request.response
                 for request in self.all_requests
-                if request.response.nonce == request.nonce]
+                if request.response.received_hash == request.sent_hash]
 
     @property
     def new_responses(self):

--- a/loadbalancer_interface/schemas/v1.py
+++ b/loadbalancer_interface/schemas/v1.py
@@ -18,7 +18,7 @@ class Response(SchemaWrapper):
         success = fields.Bool(required=True)
         message = fields.Str(missing=None)
         address = fields.Str(missing=None)
-        nonce = fields.Str(missing=None)
+        received_hash = fields.Str(missing=None)
 
         @validates_schema
         def _validate(self, data, **kwargs):
@@ -30,7 +30,6 @@ class Response(SchemaWrapper):
     def __init__(self, request):
         super().__init__()
         self._name = request.name
-        self._req_nonce = request.nonce
 
     @property
     def name(self):
@@ -73,7 +72,7 @@ class Request(SchemaWrapper):
         tls_key = fields.Str(missing=None)
         ingress_address = fields.Str(missing=None)
         ingress_ports = fields.List(fields.Int(), missing=list)
-        nonce = fields.Str(missing=None)
+        sent_hash = fields.Str(missing=None)
 
     @classmethod
     def _from_id(cls, req_id, relations):

--- a/loadbalancer_interface/schemas/v1.py
+++ b/loadbalancer_interface/schemas/v1.py
@@ -85,6 +85,12 @@ class Request(SchemaWrapper):
     def name(self):
         return self._name
 
+    @property
+    def id(self):
+        if self.relation is None:
+            return None
+        return '{}:{}'.format(self.relation.id, self.name)
+
     @classmethod
     def loads(cls, name, request_sdata, response_sdata=None):
         self = cls(name)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 SETUP = {
     "name": "loadbalancer_interface",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": "Cory Johns",
     "author_email": "cory.johns@canonical.com",
     "url": "https://github.com/juju-solutions/loadbalancer-interface",

--- a/tests/unit/test_schema_v1.py
+++ b/tests/unit/test_schema_v1.py
@@ -29,6 +29,9 @@ def test_request():
     assert req.version == 1
     assert req.health_checks == []
     assert req.dump()
+    assert req.id is None
+    req.relation = Mock(id='0')
+    assert req.id == '0:name'
 
     hc = HealthCheck()._update(traffic_type='https', port=443)
     req.health_checks.append(hc)

--- a/tests/unit/test_schema_v1.py
+++ b/tests/unit/test_schema_v1.py
@@ -35,11 +35,13 @@ def test_request():
 
     hc = HealthCheck()._update(traffic_type='https', port=443)
     req.health_checks.append(hc)
-    assert req.hash == '227e12b7f5eb3388ac931e89a3510285'
+    assert req.hash == 'af61d5d3e4f6491417370adc02d9707a'
+    req.nonce = req.hash
+    assert req.hash == 'f6291062edc7734366ed1269a31f8971'
     hc.port = 6443
-    assert req.hash == 'f0ab4768bc530703691fa4dd530e97a5'
+    assert req.hash == 'ff0d4439b67c47e3e4cccd6d719eb467'
     req.repsonse = 'foo'
-    assert req.hash == 'f0ab4768bc530703691fa4dd530e97a5'
+    assert req.hash == 'ff0d4439b67c47e3e4cccd6d719eb467'
 
     req.traffic_type = None
     with pytest.raises(ValidationError):
@@ -50,12 +52,12 @@ def test_request():
     req2 = Request.loads('name', req.dumps(), '{'
                          ' "success": true,'
                          ' "address": "foo",'
-                         ' "request_hash": "f0ab4768bc530703691fa4dd530e97a5"'
+                         ' "nonce": "af61d5d3e4f6491417370adc02d9707a"'
                          '}')
     assert req2.hash == req.hash
     assert req2.response.success
     assert req2.response.address == 'foo'
-    assert req2.response.request_hash == req.hash
+    assert req2.response.nonce == req.nonce
 
 
 def test_response():
@@ -66,31 +68,31 @@ def test_response():
     with pytest.raises(ValidationError):
         Response(request)._update(success=True,
                                   address=None,
-                                  request_hash=None)
+                                  nonce=None)
     with pytest.raises(ValidationError):
         Response(request)._update(success=True,
                                   address='https://my-lb.aws.com/',
-                                  response_hash='',
+                                  nonce='',
                                   foo='bar')
     with pytest.raises(ValidationError):
         Response(request)._update(success=False,
                                   address='https://my-lb.aws.com/',
-                                  request_hash='')
+                                  nonce='')
 
     resp = Response(request)._update(success=True,
                                      address='https://my-lb.aws.com/',
-                                     request_hash='')
+                                     nonce='')
     assert resp.name == 'name'
-    assert resp.hash == '6718fe59d99020ba3fd5a73efad4ea32'
+    assert resp.hash == 'a9f96770e9b5066fd02fa2d1284a19fb'
     resp.foo = 'bar'
-    assert resp.hash == '6718fe59d99020ba3fd5a73efad4ea32'
+    assert resp.hash == 'a9f96770e9b5066fd02fa2d1284a19fb'
 
     resp.success = False
     with pytest.raises(ValidationError):
         resp.dump()
     assert resp.hash is None
     resp.message = 'foo'
-    assert resp.hash == '2b1db528eccd3b5818032fe8b113d069'
+    assert resp.hash == 'd33c2b74d4d62cba643f13ab990827e5'
 
     resp2 = Response(request)._update(resp.dump())
     assert resp2.hash == resp.hash


### PR DESCRIPTION
To allow for resources to be properly cleaned up when LBs are no longer needed or relations are removed, the interface needs to keep track of requests and responses which have been removed, either explicitly or due to the relation being removed.

Working on this also uncovered an issue with how request changes were being tracked on the providing side which had to be sorted out.