### PR TITLE
Replace backend_ports and ingress_ports with port_mapping

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -87,7 +87,7 @@ Acquired from `LBProvider.get_request(name)`, `LBConsumers.all_requests`, or `LB
 
   * `traffic_type` Type of traffic to route (`str`, required)
   * `backends` List of backend addresses (`str`s, default: every units' `ingress-address`)
-  * `backend_ports` List of ports or `range`s to route (`int`s or `range(int, int)`, required)
+  * `port_mapping` Mapping of ingress ports to backend ports (`dict[int -> int]`, required)
   * `algorithm` List of traffic distribution algorithms, in order of preference (`str`s, optional)
   * `sticky` Whether traffic "sticks" to a given backend (`bool`, default: `False`)
   * `health_checks` List of `HealthCheck` objects (see below, optional)
@@ -96,7 +96,6 @@ Acquired from `LBProvider.get_request(name)`, `LBConsumers.all_requests`, or `LB
   * `tls_cert` If TLS termination is enabled, a manually provided cert (`str`, optional)
   * `tls_key` If TLS termination is enabled, a manually provided key (`str`, optional)
   * `ingress_address` A manually provided ingress address (optional, may not be supported)
-  * `ingress_ports` A list of ingress ports or `range`s (`int`s or `range(int, int)`; default: `backend_ports`)
 
 ### Methods
 

--- a/docs/examples/requires_operator.md
+++ b/docs/examples/requires_operator.md
@@ -34,7 +34,7 @@ class MyCharm(CharmBase):
     def _request_lb(self, event):
         request = self.lb_provider.get_request('my-service')
         request.traffic_type = 'https'
-        request.backend_ports = [443]
+        request.port_mapping = {443: 443}
         self.lb_provider.send_request(request)
 
     def _get_lb(self, event):

--- a/docs/examples/requires_reactive.md
+++ b/docs/examples/requires_reactive.md
@@ -22,7 +22,7 @@ def request_lb():
     lb_provider = endpoint_from_name('lb-provider')
     lb_provider.get_request('my-service')
     request.traffic_type = 'https'
-    request.backend_ports = [443]
+    request.port_mapping = {443: 443}
     lb_provider.send_request(request)
 
 

--- a/loadbalancer_interface/schemas/v1.py
+++ b/loadbalancer_interface/schemas/v1.py
@@ -62,7 +62,9 @@ class Request(SchemaWrapper):
     class _Schema(Schema):
         traffic_type = fields.Str(required=True)
         backends = fields.List(fields.Str(), missing=list)
-        backend_ports = fields.List(fields.Int(), required=True)
+        port_mapping = fields.Dict(
+            keys=fields.Int(), values=fields.Int(), required=True
+        )
         algorithm = fields.List(fields.Str(), missing=list)
         sticky = fields.Bool(missing=False)
         health_checks = fields.List(HealthCheckField, missing=list)
@@ -71,7 +73,6 @@ class Request(SchemaWrapper):
         tls_cert = fields.Str(missing=None)
         tls_key = fields.Str(missing=None)
         ingress_address = fields.Str(missing=None)
-        ingress_ports = fields.List(fields.Int(), missing=list)
         sent_hash = fields.Str(missing=None)
 
     @classmethod

--- a/tests/functional/test_interface.py
+++ b/tests/functional/test_interface.py
@@ -221,7 +221,7 @@ class ConsumerCharm(CharmBase):
     def request_lb(self, name, backends=None):
         request = self.lb_provider.get_request(name)
         request.traffic_type = "https"
-        request.backend_ports = [443]
+        request.port_mapping = {443: 443}
         if backends is not None:
             request.backends = backends
         self.lb_provider.send_request(request)

--- a/tests/unit/test_schema_v1.py
+++ b/tests/unit/test_schema_v1.py
@@ -28,13 +28,15 @@ def test_request():
     with pytest.raises(TypeError):
         Request(foo="foo")
     with pytest.raises(ValidationError):
-        Request("name")._update(traffic_type="https", backend_ports=["none"])
+        Request("name")._update(traffic_type="https", port_mapping={"none": "none"})
     with pytest.raises(ValidationError):
-        Request("name")._update(traffic_type="https", backend_ports=[443], foo="bar")
+        Request("name")._update(
+            traffic_type="https", port_mapping={443: 443}, foo="bar"
+        )
 
     req = Request("name")
     req.traffic_type = "https"
-    req.backend_ports = [443]
+    req.port_mapping = {443: 443}
     assert req.version == 1
     assert req.health_checks == []
     assert req.dump()


### PR DESCRIPTION
Switch to a less confusing `port_mapping` structure instead of two lists which must be kept in sync. Also remove a reference to supporting ranges, which don't work and likely aren't needed.