### PR TITLE
Rename traffic_type to protocol and make enum

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -77,6 +77,15 @@ Represents a request for a load balancer.
 
 Acquired from `LBProvider.get_request(name)`, `LBConsumers.all_requests`, or `LBConsumers.new_requests`.
 
+### Class Attributes
+
+  * `protocols` An Enum of possible values for the Request or HealthCheck `protocol` field.
+    Can be one of:
+    * `protocols.tcp`
+    * `protocols.udp`
+    * `protocols.http`
+    * `protocols.https`
+
 ### Properties
 
   * `name` Name of the request (`str`, read-only)
@@ -85,7 +94,7 @@ Acquired from `LBProvider.get_request(name)`, `LBConsumers.all_requests`, or `LB
 
 ### Fields
 
-  * `traffic_type` Type of traffic to route (`str`, required)
+  * `protocol` Type of traffic to route (`Request.protocols`, required)
   * `backends` List of backend addresses (`str`s, default: every units' `ingress-address`)
   * `port_mapping` Mapping of ingress ports to backend ports (`dict[int -> int]`, required)
   * `algorithm` List of traffic distribution algorithms, in order of preference (`str`s, optional)
@@ -110,7 +119,7 @@ Acquired from `Request.add_health_check()`, or `Request.health_checks`.
 
 ### Fields
 
-  * `traffic_type` Type of traffic to use to make the check (e.g., "https", "udp", etc.) (`str`, required)
+  * `protocol` Type of traffic to use to make the check (e.g., "https", "udp", etc.) (`Request.protocols`, required)
   * `port` Port to check on (`int`, required)
   * `path` Path on the backend to check (e.g., for "https" or "http" types) (`str`, optional)
   * `interval` How many seconds to wait between checks (`int`, default: 30)

--- a/docs/examples/requires_operator.md
+++ b/docs/examples/requires_operator.md
@@ -33,7 +33,7 @@ class MyCharm(CharmBase):
 
     def _request_lb(self, event):
         request = self.lb_provider.get_request('my-service')
-        request.traffic_type = 'https'
+        request.protocol = request.protocols.https
         request.port_mapping = {443: 443}
         self.lb_provider.send_request(request)
 

--- a/docs/examples/requires_reactive.md
+++ b/docs/examples/requires_reactive.md
@@ -21,7 +21,7 @@ from charms import layer
 def request_lb():
     lb_provider = endpoint_from_name('lb-provider')
     lb_provider.get_request('my-service')
-    request.traffic_type = 'https'
+    request.protocol = request.protocols.https
     request.port_mapping = {443: 443}
     lb_provider.send_request(request)
 

--- a/loadbalancer_interface/schemas/v1.py
+++ b/loadbalancer_interface/schemas/v1.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 
 from marshmallow import (
     Schema,
@@ -6,11 +7,19 @@ from marshmallow import (
     validates_schema,
     ValidationError,
 )
+from marshmallow_enum import EnumField
 
 from .base import SchemaWrapper
 
 
 version = 1
+
+
+class protocols(Enum):
+    tcp = "tcp"
+    udp = "udp"
+    http = "http"
+    https = "https"
 
 
 class Response(SchemaWrapper):
@@ -41,7 +50,7 @@ class Response(SchemaWrapper):
 
 class HealthCheck(SchemaWrapper):
     class _Schema(Schema):
-        traffic_type = fields.Str(required=True)
+        protocol = EnumField(protocols, by_value=True, required=True)
         port = fields.Int(required=True)
         path = fields.Str(missing=None)
         interval = fields.Int(missing=30)
@@ -59,8 +68,10 @@ class HealthCheckField(fields.Field):
 
 
 class Request(SchemaWrapper):
+    protocols = protocols
+
     class _Schema(Schema):
-        traffic_type = fields.Str(required=True)
+        protocol = EnumField(protocols, by_value=True, required=True)
         backends = fields.List(fields.Str(), missing=list)
         port_mapping = fields.Dict(
             keys=fields.Int(), values=fields.Int(), required=True

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ SETUP = {
         "ops>=1.0.0",
         "cached_property",
         "marshmallow",
+        "marshmallow-enum",
         "ops_reactive_interface",
     ],
     "entry_points": {

--- a/tests/functional/test_interface.py
+++ b/tests/functional/test_interface.py
@@ -220,7 +220,7 @@ class ConsumerCharm(CharmBase):
 
     def request_lb(self, name, backends=None):
         request = self.lb_provider.get_request(name)
-        request.traffic_type = "https"
+        request.protocol = request.protocols.https
         request.port_mapping = {443: 443}
         if backends is not None:
             request.backends = backends


### PR DESCRIPTION
Renames the `traffic_type` field to `protocol` since that is the more commonly used term, and makes the value of the field an enum which can be accessed off of the request object or class.