### PR TITLE
Don't depend on hooks to set the schema version

### DIFF
--- a/loadbalancer_interface/base.py
+++ b/loadbalancer_interface/base.py
@@ -19,20 +19,11 @@ class VersionedInterface(Object):
         # Future-proof against the need to evolve the relation protocol
         # by ensuring that we agree on a version number before starting.
         # This may or may not be made moot by a future feature in Juju.
-        for event in (
-            charm.on[relation_name].relation_created,
-            charm.on.leader_elected,
-            charm.on.upgrade_charm,
-        ):
-            self.framework.observe(event, self._set_version)
+        self._set_version()
 
-    def _set_version(self, event):
+    def _set_version(self):
         if self.unit.is_leader():
-            if hasattr(event, "relation"):
-                relations = [event.relation]
-            else:
-                relations = self.model.relations.get(self.relation_name, [])
-            for relation in relations:
+            for relation in self.model.relations.get(self.relation_name, []):
                 relation.data[self.app]["version"] = str(schemas.max_version)
 
     @cached_property

--- a/tests/functional/test_interface.py
+++ b/tests/functional/test_interface.py
@@ -84,6 +84,7 @@ def test_interface():
     # Confirm that only leaders set the version.
     assert not get_rel_data(provider, p_app)
     provider.set_leader(True)
+    p_charm.lb_consumers._set_version()
     assert get_rel_data(provider, p_app) == {"version": "1"}
     assert not c_charm.lb_provider.is_available  # waiting on remote version
     assert not c_charm.lb_provider.can_request  # waiting on remote version
@@ -96,6 +97,7 @@ def test_interface():
     # Verify that becoming leader completes the version negotiation process and
     # allows sending requests.
     consumer.set_leader(True)
+    c_charm.lb_provider._set_version()
     assert c_charm.lb_provider.can_request
     assert get_rel_data(consumer, c_app) == {"version": "1"}
     transmit_rel_data(consumer, provider)


### PR DESCRIPTION
Only setting the schema version on specific hooks makes things a bit fragile, particularly in reactive charms (see [charm-tools#601][]), so instead just always try do it during `__init__`, regardless of the hook.

[charm-tools#601]: https://github.com/juju/charm-tools/pull/601