### PR TITLE
Use UUID for request rather than a constructed one

### DIFF
--- a/loadbalancer_interface/provides.py
+++ b/loadbalancer_interface/provides.py
@@ -59,7 +59,7 @@ class LBConsumers(VersionedInterface):
                     continue
                 name = key[len("request_") :]
                 response_sdata = local_data.get("response_" + name)
-                request = schema.Request.loads(name, request_sdata, response_sdata)
+                request = schema.Request.loads(request_sdata, response_sdata)
                 request.relation = relation
                 if not request.backends:
                     for unit in sorted(relation.units, key=attrgetter("name")):
@@ -87,10 +87,12 @@ class LBConsumers(VersionedInterface):
         current_ids = {request.id for request in self.all_requests}
         unknown_ids = self.state.known_requests.keys() - current_ids
         schema = self._schema()
-        return [
-            schema.Request._from_id(req_id, self.relations)
-            for req_id in sorted(unknown_ids)
-        ]
+        removed_requests = []
+        for req_id in sorted(unknown_ids):
+            request = schema.Request()
+            request.id = req_id
+            removed_requests.append(request)
+        return removed_requests
 
     def send_response(self, request):
         """Send a specific request's response."""

--- a/loadbalancer_interface/requires.py
+++ b/loadbalancer_interface/requires.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from cached_property import cached_property
 
 from ops.framework import (
@@ -91,9 +93,11 @@ class LBProvider(VersionedInterface):
         if request_key in local_data:
             request_sdata = local_data[request_key]
             response_sdata = remote_data.get(response_key)
-            request = schema.Request.loads(name, request_sdata, response_sdata)
+            request = schema.Request.loads(request_sdata, response_sdata)
         else:
-            request = schema.Request(name)
+            request = schema.Request()
+            request.name = name
+            request.id = uuid4().hex
         return request
 
     def get_response(self, name):

--- a/tests/functional/test_interface.py
+++ b/tests/functional/test_interface.py
@@ -78,9 +78,6 @@ def test_interface():
         },
     )
 
-    foo_id = "{}:foo".format(provider._rid)
-    bar_id = "{}:bar".format(provider._rid)
-
     # Confirm that only leaders set the version.
     assert not get_rel_data(provider, p_app)
     provider.set_leader(True)
@@ -104,6 +101,7 @@ def test_interface():
 
     # Test creating and sending a request.
     c_charm.request_lb("foo")
+    foo_id = c_charm.lb_provider.get_request("foo").id
     transmit_rel_data(consumer, provider)
     assert foo_id in p_charm.lb_consumers.state.known_requests
     assert p_charm.lb_consumers.all_requests[0].backends == [
@@ -150,6 +148,7 @@ def test_interface():
 
     # Test sending a second request
     c_charm.request_lb("bar")
+    bar_id = c_charm.lb_provider.get_request("bar").id
     transmit_rel_data(consumer, provider)
     transmit_rel_data(provider, consumer)
     assert bar_id in p_charm.lb_consumers.state.known_requests

--- a/tests/unit/test_schema_v1.py
+++ b/tests/unit/test_schema_v1.py
@@ -28,23 +28,29 @@ def test_request():
     with pytest.raises(TypeError):
         Request(foo="foo")
     with pytest.raises(ValidationError):
-        Request("name")._update(
-            protocol=Request.protocols.https, port_mapping={"none": "none"}
+        Request()._update(
+            name="foo",
+            id="foo",
+            protocol=Request.protocols.https,
+            port_mapping={"none": "none"},
         )
     with pytest.raises(ValidationError):
-        Request("name")._update(
-            protocol=Request.protocols.https, port_mapping={443: 443}, foo="bar"
+        Request()._update(
+            name="foo",
+            id="foo",
+            protocol=Request.protocols.https,
+            port_mapping={443: 443},
+            foo="bar",
         )
 
-    req = Request("name")
+    req = Request()
+    req.name = "name"
+    req.id = "id"
     req.protocol = req.protocols.https
     req.port_mapping = {443: 443}
     assert req.version == 1
     assert req.health_checks == []
     assert req.dump()
-    assert req.id is None
-    req.relation = Mock(id="0")
-    assert req.id == "0:name"
 
     hc = HealthCheck()._update(protocol=req.protocols.https, port=443)
     req.health_checks.append(hc)
@@ -63,7 +69,6 @@ def test_request():
     req.protocol = req.protocols.https
 
     req2 = Request.loads(
-        "name",
         req.dumps(),
         '{"address": "foo", "received_hash": "%s"}' % req.sent_hash,
     )


### PR DESCRIPTION
The constructed request ID isn't guaranteed to be unique across controllers. This probably won't be an issue, but if the ID is used to tag resources to ensure they can be cleaned up, there is a small potential for conflict if multiple controllers are in use. It's safer
and easier to just generate a UUID instead.

In the name of simplicity, this also makes the name and ID into regular fields, as well.