### PR TITLE
Be more graceful when reading requests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     flake8
     black
 commands =
-    flake8 --exclude .*
+    flake8 --exclude .*,build
     black --check loadbalancer_interface tests examples
 
 [testenv:unit]


### PR DESCRIPTION
Only consider writing bad requests / responses as fatal. On read, instead just log the error and skip it.