### PR TITLE
Allow non-leaders to see responses

### DIFF
--- a/tests/functional/test_interface.py
+++ b/tests/functional/test_interface.py
@@ -138,6 +138,14 @@ def test_interface():
 
     # Test updating the request and getting an updated response.
     c_charm.request_lb("foo", ["192.168.0.5"])
+    lb_p = c_charm.lb_provider
+    assert len(lb_p.complete_responses) != len(lb_p.all_responses)
+    consumer.set_leader(False)
+    # non-leaders can't read app-level relation data set by their own leader, so can't
+    # verify whether a response has been updated or not; however, they should still be
+    # able to read responses
+    assert len(lb_p.complete_responses) == len(lb_p.all_responses)
+    consumer.set_leader(True)
     transmit_rel_data(consumer, provider)
     transmit_rel_data(provider, consumer)
     assert p_charm.lb_consumers.all_requests[0].backends == ["192.168.0.5"]


### PR DESCRIPTION
For whatever reason, non-leaders are blocked from reading app-level relation data set by the leader. This means they can't read the list of requests nor compare the hashes of those requests to see if the responses are complete. This works around that by just having non-leaders assume that any provided response is complete.

Part of [lp:1921776][]

[lp:1921776]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1921776