### PR TITLE
provider followers perms to read all_requests without writing on relation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -59,6 +59,7 @@ When instantiated, it should be passed a charm instance and a relation name.
 ### Methods
 
   * `send_response(request)` Send the completed `Response` attached to the given `Request`
+  * `follower_perms(*, read=..., write=...)` Set permissions for follower units to access requests
 
 ### Properties
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,7 @@ When instantiated, it should be passed a charm instance and a relation name.
 ### Methods
 
   * `send_response(request)` Send the completed `Response` attached to the given `Request`
-  * `follower_perms(*, read=..., write=...)` Set permissions for follower units to access requests
+  * `follower_perms(*, read=...)` Set permissions for follower units to access requests
 
 ### Properties
 

--- a/examples/lb-provider-reactive/reactive/charm.py
+++ b/examples/lb-provider-reactive/reactive/charm.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
 
 from charms.reactive import when, when_not, set_flag, endpoint_from_name
+from charms.reactive import hook
 from charms import layer
+
+
+@hook("upgrade-charm")
+def upgrade_charm():
+    lb_consumers = endpoint_from_name("lb-consumers")
+    lb_consumers.follower_perms(read=True)
 
 
 @when_not("charm.status.is-set")

--- a/examples/lb-provider-reactive/reactive/charm.py
+++ b/examples/lb-provider-reactive/reactive/charm.py
@@ -5,10 +5,10 @@ from charms.reactive import hook
 from charms import layer
 
 
-@hook("upgrade-charm")
-def upgrade_charm():
+def allow_lb_consumers_to_read_requests():
     lb_consumers = endpoint_from_name("lb-consumers")
     lb_consumers.follower_perms(read=True)
+    return lb_consumers
 
 
 @when_not("charm.status.is-set")
@@ -20,7 +20,7 @@ def set_status():
 @when("endpoint.lb-consumers.requests_changed")
 def get_lb():
     layer.status.maintenance("processing requests")
-    lb_consumers = endpoint_from_name("lb-consumers")
+    lb_consumers = allow_lb_consumers_to_read_requests()
     for request in lb_consumers.new_requests:
         response = request.response
         if not request.public:

--- a/examples/lb-provider-reactive/reactive/charm.py
+++ b/examples/lb-provider-reactive/reactive/charm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from charms.reactive import when, when_not, set_flag, endpoint_from_name
-from charms.reactive import hook
 from charms import layer
 
 

--- a/loadbalancer_interface/provides.py
+++ b/loadbalancer_interface/provides.py
@@ -122,6 +122,7 @@ class LBConsumers(VersionedInterface):
         if not self.unit.is_leader():
             # This unit is a follower which cannot write to
             # relation.data[self.app]
+            log.warning("Non-leader unit cannot send response")
             return
 
         request.response.received_hash = request.sent_hash

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from shutil import rmtree
 
 SETUP = {
     "name": "loadbalancer_interface",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "author": "Cory Johns",
     "author_email": "cory.johns@canonical.com",
     "url": "https://github.com/juju-solutions/loadbalancer-interface",

--- a/tests/functional/test_interface.py
+++ b/tests/functional/test_interface.py
@@ -126,7 +126,7 @@ def test_interface(request):
     provider.set_leader(False)
     assert len(p_charm.lb_consumers.all_requests) == 0
 
-    # Confirm non-leaders cannot see requests with read permission
+    # Confirm non-leaders can see requests with read permission
     p_charm.lb_consumers.follower_perms(read=True)
     assert len(p_charm.lb_consumers.all_requests) == 1
 

--- a/tests/functional/test_interface.py
+++ b/tests/functional/test_interface.py
@@ -58,9 +58,11 @@ def test_interface(request):
 
     p_charm = provider.charm
     p_app = p_charm.app
+    p_unit_0 = p_charm.unit
+
     c_charm = consumer.charm
     c_app = c_charm.app
-    c_unit0 = consumer.charm.unit
+    c_unit0 = c_charm.unit
     c_unit1 = add_peer_unit(consumer)
 
     # Setup initial relation with only Juju-provided automatic data.
@@ -70,8 +72,8 @@ def test_interface(request):
     # relation, so it's critical to add a remote unit before any local units.
     provider.add_relation_unit(provider._rid, c_unit0.name)
     provider.add_relation_unit(provider._rid, c_unit1.name)
-    provider.add_relation_unit(provider._rid, p_charm.unit.name)
-    consumer.add_relation_unit(consumer._rid, p_charm.unit.name)
+    provider.add_relation_unit(provider._rid, p_unit_0.name)
+    consumer.add_relation_unit(consumer._rid, p_unit_0.name)
     consumer.add_relation_unit(consumer._rid, c_unit0.name)
     consumer.add_relation_unit(consumer._rid, c_unit1.name)
     update_rel_data(
@@ -82,8 +84,12 @@ def test_interface(request):
         },
     )
 
-    # Confirm that only leaders set the version.
+    # Confirm that non-leaders cannot set the version.
+    provider.set_leader(False)
+    p_charm.lb_consumers._set_version()
     assert not get_rel_data(provider, p_app)
+
+    # Confirm that only leaders set the version.
     provider.set_leader(True)
     p_charm.lb_consumers._set_version()
     assert get_rel_data(provider, p_app) == {"version": "1"}
@@ -108,13 +114,28 @@ def test_interface(request):
     foo_id = c_charm.lb_provider.get_request("foo").id
     transmit_rel_data(consumer, provider)
     assert foo_id in p_charm.lb_consumers.state.known_requests
+
+    # Confirm leaders can read requests
     assert p_charm.lb_consumers.all_requests[0].backends == [
         "192.168.0.5",
         "192.168.0.3",
     ]
     assert p_charm.changes == {"foo": 1}
 
+    # Confirm non-leaders cannot read requests
+    provider.set_leader(False)
+    assert len(p_charm.lb_consumers.all_requests) == 0
+
+    # Confirm non-leaders cannot see requests with read permission
+    p_charm.lb_consumers.follower_perms(read=True)
+    assert len(p_charm.lb_consumers.all_requests) == 1
+
+    # Confirm non-leaders cannot see requests without read permission
+    p_charm.lb_consumers.follower_perms(read=False)
+    assert len(p_charm.lb_consumers.all_requests) == 0
+
     # Test receiving the response
+    provider.set_leader(True)
     assert not c_charm.active_lbs
     assert not c_charm.failed_lbs
     transmit_rel_data(provider, consumer)

--- a/tests/integration/test_lb_interface.py
+++ b/tests/integration/test_lb_interface.py
@@ -10,15 +10,16 @@ log = logging.getLogger(__name__)
 async def test_build_and_deploy(ops_test, lb_charms):
     lb_lib_path = await ops_test.build_lib(".")
     lb_charms._lb_lib_url = lb_lib_path
-    bundle = ops_test.render_bundle(
-        "tests/integration/bundle.yaml",
-        charms=await ops_test.build_charms(
-            lb_charms.lb_provider,
+    charms: dict = await ops_test.build_charms(lb_charms.lb_provider)
+    charms.update(
+        **await ops_test.build_charms(
             lb_charms.lb_consumer,
             lb_charms.lb_provider_reactive,
             lb_charms.lb_consumer_reactive,
-        ),
+        )
     )
+
+    bundle = ops_test.render_bundle("tests/integration/bundle.yaml", charms=charms)
     log.info("Deploying bundle")
     await ops_test.model.deploy(bundle)
     await ops_test.model.wait_for_idle(


### PR DESCRIPTION
[LP#2017814](https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/2017814)

When a charm with this interface is scaled-out, only the leader unit has access to the request data over this interface to create a response.  It is however necessary in some cases to expose the request data to the follower charms, so they can configure their units according to the request.  

Create a state  flag set by the charm to control the permissions of the follower charms
